### PR TITLE
Update to the latest zint, support Ubuntu 20.04.

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -27,8 +27,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - geerlingguy/docker-ubuntu1804-ansible:latest
-          - geerlingguy/docker-ubuntu1604-ansible:latest
+          - geerlingguy/docker-ubuntu2004-ansible:latest
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 
-* Ubuntu LTS (14.04 or newer)
+* Ubuntu LTS (20.04 or newer)
 
 ## Role Variables
 
@@ -23,9 +23,9 @@ None
     - roles:
         - name: Install Zint from source
           role: acromedia.zint
-          zint_version: 2.4.2
-          zint_source: "https://github.com/downloads/zint/zint/zint-{{ zint_version }}.tar.gz"
-          zint_source_checksum: 'sha256:76547faaba0bfbea43733ab324e498863ebf21fc9a2e5db93512739d661a2b3a'
+          zint_version: 2.9.1
+          zint_source: "https://sourceforge.net/projects/zint/files/zint/{{ zint_version }}/zint-{{ zint_version }}-src.tar.gz/download"
+          zint_source_checksum: 'sha256:bd286d863bc60d65a805ec3e46329c5273a13719724803b0ac02e5b5804c596a'
       tags:
         - zint
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 - Install Zint's build prerequisites
 - Build and Install Zint from source on Ubuntu
 
+## Updating Zint
+
+The role does not support updating Zint. To change the installed version of
+Zint, first delete `/usr/local/bin/zint`, then install the new version.
+
 ## Requirements
 
 * Ubuntu LTS (20.04 or newer)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-zint_version: 2.4.3
-zint_source: "https://github.com/downloads/zint/zint/zint-{{ zint_version }}.tar.gz"
-zint_source_checksum: 'sha256:de2f4fd0d008530511f5dea2cff7f96f45df4c029b57431b2411b7e1f3a523e8'
+zint_version: 2.9.1
+zint_source: "https://github.com/downloads/zint/zint/zint-{{ zint_version }}-src.tar.gz"
+zint_source_checksum: 'sha256:bd286d863bc60d65a805ec3e46329c5273a13719724803b0ac02e5b5804c596a'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 zint_version: 2.9.1
-zint_source: "https://github.com/downloads/zint/zint/zint-{{ zint_version }}-src.tar.gz"
+zint_source: "https://sourceforge.net/projects/zint/files/zint/{{ zint_version }}/zint-{{ zint_version }}-src.tar.gz/download"
 zint_source_checksum: 'sha256:bd286d863bc60d65a805ec3e46329c5273a13719724803b0ac02e5b5804c596a'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,8 +8,6 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - trusty
-    - xenial
-    - bionic
+    - focal
   galaxy_tags: []
 dependencies: []

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1604-ansible:latest'}
+    image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu2004-ansible:latest'}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,7 @@
   when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
 
 - name: Check the current version of Zint
-  shell: |
-    grep "Zint version {{ zint_version }}" <(zint --help)
+  shell: 'zint --help | grep "Zint version {{ zint_version }}"'
   when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
   register: zint_version_check
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Check the current version of Zint
   shell: |
-    grep "Zint version {{ zint_version }}" $(zint --help)
+    grep "Zint version {{ zint_version }}" <(zint --help)
   when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
   register: zint_version_check
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     remote_src: true
     src: "/usr/local/src/zint/zint-{{ zint_version }}.tar.gz"
     dest: "/usr/local/src/zint/"
-    creates: "/usr/local/src/zint/zint-{{ zint_version }}/"
+    creates: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
     owner: root
     group: root
 
@@ -40,12 +40,12 @@
 
 - name: Build Zint
   make:
-    chdir: "/usr/local/src/zint/zint-{{ zint_version }}/"
+    chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
   when: cmake_result.changed
 
 - name: Install Zint
   make:
-    chdir: "/usr/local/src/zint/zint-{{ zint_version }}/"
+    chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
     target: install
   when: cmake_result.changed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,5 @@
   with_items:
     - 'g++'
     - cmake
-    - libqt4-dev
     - zlib1g-dev
     - libpng-dev

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,13 +14,8 @@
     msg: "Zint exists"
   when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
 
-- name: Check the current version of Zint
-  shell: 'zint --help | grep "Zint version {{ zint_version }}"'
-  when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
-  register: zint_version_check
-
 - name: Install Zint
-  when: zint_stat.stat.isreg is not defined or zint_version_check.rc != '0'
+  when: zint_stat.stat.isreg is not defined
   block:
     - name: Install Zint pre-requisites
       apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,8 +34,8 @@
 - name: Create Zint's makefile
   shell: /usr/bin/cmake .
   args:
-    chdir: /usr/local/src/zint/zint-{{ zint_version }}
-    creates: /usr/local/src/zint/zint-{{ zint_version }}/CMakeFiles/Makefile.cmake
+    chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src"
+    creates: "/usr/local/src/zint/zint-{{ zint_version }}-src/CMakeFiles/Makefile.cmake"
   register: cmake_result
 
 - name: Build Zint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,13 @@
 ---
 - name: Install Zint pre-requisites
   apt:
-    name: "{{ item }}"
+    name:
+      - 'g++'
+      - cmake
+      - zlib1g-dev
+      - libpng-dev
     state: present
     update_cache: yes
-  with_items:
-    - 'g++'
-    - cmake
-    - zlib1g-dev
-    - libpng-dev
 
 - name: Create a dir for the Zint source code
   file:
@@ -51,10 +50,9 @@
 
 - name: Uninstall Zint pre-requisites
   apt:
-    name: "{{ item }}"
+    name:
+      - 'g++'
+      - cmake
+      - zlib1g-dev
+      - libpng-dev
     state: absent
-  with_items:
-    - 'g++'
-    - cmake
-    - zlib1g-dev
-    - libpng-dev

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,6 @@
   with_items:
     - 'g++'
     - cmake
-    - libqt4-dev
     - zlib1g-dev
     - libpng-dev
 
@@ -49,3 +48,14 @@
     chdir: "/usr/local/src/zint/zint-{{ zint_version }}/"
     target: install
   when: cmake_result.changed
+
+- name: Uninstall Zint pre-requisites
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - 'g++'
+    - cmake
+    - libqt4-dev
+    - zlib1g-dev
+    - libpng-dev

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,58 +1,82 @@
 ---
-- name: Install Zint pre-requisites
-  apt:
-    name:
-      - 'g++'
-      - cmake
-      - zlib1g-dev
-      - libpng-dev
-    state: present
-    update_cache: yes
+- name: Check whether Zint is installed
+  stat:
+    path: "/usr/local/bin/zint"
+  register: zint_stat
 
-- name: Create a dir for the Zint source code
-  file:
-    state: directory
-    path: "/usr/local/src/zint"
-    recurse: true
+- name: Print a debug message if Zint is uninstalled
+  debug:
+    msg: "Zint doesn't exist"
+  when: zint_stat.stat.isreg is not defined
 
-- name: Download Zint source code
-  get_url:
-    url: "{{ zint_source }}"
-    dest: "/usr/local/src/zint/zint-{{ zint_version }}.tar.gz"
-    checksum: "{{ zint_source_checksum }}"
+- name: Print a debug message if Zint is installed
+  debug:
+    msg: "Zint exists"
+  when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
 
-- name: Extract Zint source code
-  unarchive:
-    remote_src: true
-    src: "/usr/local/src/zint/zint-{{ zint_version }}.tar.gz"
-    dest: "/usr/local/src/zint/"
-    creates: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
-    owner: root
-    group: root
-
-- name: Create Zint's makefile
-  shell: /usr/bin/cmake .
-  args:
-    chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src"
-    creates: "/usr/local/src/zint/zint-{{ zint_version }}-src/CMakeFiles/Makefile.cmake"
-  register: cmake_result
-
-- name: Build Zint
-  make:
-    chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
-  when: cmake_result.changed
+- name: Check the current version of Zint
+  shell: |
+    grep "Zint version {{ zint_version }}" $(zint --help)
+  when: zint_stat.stat.isreg is defined and zint_stat.stat.isreg
+  register: zint_version_check
 
 - name: Install Zint
-  make:
-    chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
-    target: install
-  when: cmake_result.changed
+  when: zint_stat.stat.isreg is not defined or zint_version_check.rc != '0'
+  block:
+    - name: Install Zint pre-requisites
+      apt:
+        name:
+          - 'g++'
+          - cmake
+          - zlib1g-dev
+          - libpng-dev
+        state: present
+        update_cache: yes
 
-- name: Uninstall Zint pre-requisites
-  apt:
-    name:
-      - 'g++'
-      - cmake
-      - zlib1g-dev
-      - libpng-dev
-    state: absent
+    - name: Create a dir for the Zint source code
+      file:
+        state: directory
+        path: "/usr/local/src/zint"
+        recurse: true
+
+    - name: Download Zint source code
+      get_url:
+        url: "{{ zint_source }}"
+        dest: "/usr/local/src/zint/zint-{{ zint_version }}.tar.gz"
+        checksum: "{{ zint_source_checksum }}"
+
+    - name: Extract Zint source code
+      unarchive:
+        remote_src: true
+        src: "/usr/local/src/zint/zint-{{ zint_version }}.tar.gz"
+        dest: "/usr/local/src/zint/"
+        creates: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
+        owner: root
+        group: root
+
+    - name: Create Zint's makefile
+      shell: /usr/bin/cmake .
+      args:
+        chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src"
+        creates: "/usr/local/src/zint/zint-{{ zint_version }}-src/CMakeFiles/Makefile.cmake"
+      register: cmake_result
+
+    - name: Build Zint
+      make:
+        chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
+      when: cmake_result.changed
+
+    - name: Install Zint
+      make:
+        chdir: "/usr/local/src/zint/zint-{{ zint_version }}-src/"
+        target: install
+      when: cmake_result.changed
+
+    - name: Uninstall Zint pre-requisites
+      apt:
+        name:
+          - 'g++'
+          - cmake
+          - zlib1g-dev
+          - libpng-dev
+        state: absent


### PR DESCRIPTION
This updates the role to not install libqt4-dev, which isn't available on Ubuntu 20.04. 20.04 has qt5, but there's no libqt5-dev. It's not necessary - I've been compiling zint >= 2.8.0 for command-line use on Ubuntu 20.04 without any qt packages.

I didn't explore how to support Ubuntu < 20.04, and automated tests only use 20.04 now. I assume it could be tricky, if libqt4 is actually required for older versions (or maybe it's only required for older versions of zint, and the new ones would work on old Ubuntu). Regardless, I don't plan on looking into it unless necessary, or we pass through a wormhole that sends us into the past.

Another task is added to remove the same packages that were installed.

This uses the latest zint by default (2.9.1). It also changes the URL from GitHub, which doesn't appear to have any releases anymore, to sourceforge. It would work with 2.8.0, since the URL is the same structure, but not with 2.4.2, which doesn't have `-src` in the URL. I'm not sure which version was the first to include `-src`, but I assume we're not very keen to support old versions anyway.