### PR TITLE
Remove need for defaults, update Ubuntu support list

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         image:
           - geerlingguy/docker-ubuntu2004-ansible:latest
-          - geerlingguy/docker-ubuntu2204-ansible:latest
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         image:
           - geerlingguy/docker-ubuntu2004-ansible:latest
+          - geerlingguy/docker-ubuntu2204-ansible:latest
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Zint, first delete `/usr/local/bin/zint`, then install the new version.
 
 ## Role Variables
 
-See example playbook.
+If these variables are not supplied, the role will just pull the latest version.
+
+```
+zint_version: 2.13.0
+zint_source: "https://sourceforge.net/projects/zint/files/zint/{{ zint_version }}/zint-{{ zint_version }}-src.tar.gz/download"
+zint_source_checksum: 'sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8'
+```
 
 ## Dependencies
 
@@ -24,6 +30,16 @@ None
 
 ## Example Playbook
 
+```yaml
+    # Just download latest
+    - hosts: servers
+    - roles:
+        - name: Install Zint from source
+          role: acromedia.zint
+      tags:
+        - zint
+
+    # ...or download a specific version
     - hosts: servers
     - roles:
         - name: Install Zint from source
@@ -33,6 +49,7 @@ None
           zint_source_checksum: 'sha256:bd286d863bc60d65a805ec3e46329c5273a13719724803b0ac02e5b5804c596a'
       tags:
         - zint
+```
 
 ## License
 
@@ -40,5 +57,5 @@ GPLv3
 
 ## Author Information
 
-Acro Media Inc.
-https://www.acromedia.com/
+Acro Commerce Inc.
+https://www.acrocommerce.com/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Zint, first delete `/usr/local/bin/zint`, then install the new version.
 
 If these variables are not supplied, the role will just pull the latest version.
 
-```
+```yaml
 zint_version: 2.13.0
 zint_source: "https://sourceforge.net/projects/zint/files/zint/{{ zint_version }}/zint-{{ zint_version }}-src.tar.gz/download"
 zint_source_checksum: 'sha256:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,0 @@
----
-zint_version: '2.11.0'
-zint_source: "https://sourceforge.net/projects/zint/files/zint/{{ zint_version }}/zint-{{ zint_version }}-src.tar.gz/download"
-zint_source_checksum: 'sha1:afca4c33ce82ec6027430a30bb58661157c0b38d'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,8 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - focal
+    - jammy
+    - noble
   namespace: acromedia
   role_name: zint
   galaxy_tags: []

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,7 +8,6 @@
     - name: Verify utilities are available
       command: >
         {{ item }}
-        with_items:
       with_items:
         - zint --help
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,25 @@
 - set_fact:
     zint_local_source_base: /usr/local/src/zint
 
+- name: Set zint version if not defined by sending a request to SourceForge
+  # https://sourceforge.net/projects/zint/best_release.json
+  uri:
+    url: "https://sourceforge.net/projects/zint/best_release.json"
+    return_content: yes
+  register: zint_version_result
+  when: zint_version is not defined
+
+- set_fact:
+    # version can be grabbed from release.filename, which looks like /zint/<version>/zint-<version>-src.tar.gz
+    zint_version: "{{ zint_version_result.json.release.filename.split('/')[2] }}"
+    zint_source_checksum: "md5:{{ zint_version_result.json.release.md5sum }}"
+  when: zint_version is not defined
+
+- name: Set source URL if not defined
+  set_fact:
+    zint_source: "https://sourceforge.net/projects/zint/files/zint/{{ zint_version }}/zint-{{ zint_version }}-src.tar.gz/download"
+  when: zint_source is not defined
+
 - set_fact:
     zint_local_source_gz: "{{ zint_local_source_base }}/zint-{{ zint_version }}.tar.gz"
     zint_local_source_dir: "{{ zint_local_source_base }}/zint-{{ zint_version }}-src"


### PR DESCRIPTION
If Zint version is not defined, the playbook will now dynamically grab the latest release from https://sourceforge.net/projects/zint/best_release.json. Also tested on Ubuntu 24.04, so support list was bumped